### PR TITLE
Upgrade rack gem to 1.6.11 due to security reasons

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
   specs:
     mocha (0.9.8)
       rake
-    rack (1.6.9)
+    rack (1.6.11)
     rake (10.3.2)
     useragent (0.10.0)
 
@@ -24,4 +24,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.16.1
+   1.17.1


### PR DESCRIPTION
This is part of issue https://github.com/bebanjo/support/issues/117

Security issues related: [CVE-2018-16471]